### PR TITLE
fix: resolve folia issue with sync tick 

### DIFF
--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/FoliaTaskManager.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/FoliaTaskManager.java
@@ -128,12 +128,9 @@ public class FoliaTaskManager extends TaskManager {
 
     @Override
     public <T> T syncGlobal(final Supplier<T> supplier) {
-        // FAWE start - Fix Folia compatibility: In Folia, there is no "primary thread"
-        // Instead, we need to check if we're on a tick thread and handle accordingly
         if (FoliaSupport.isTickThread()) {
             return supplier.get();
         }
-        // FAWE end
         final FutureTask<T> task = new FutureTask<>(supplier::get);
         Bukkit.getGlobalRegionScheduler().run(WorldEditPlugin.getInstance(), asTickConsumer(task));
         try {

--- a/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/FoliaTaskManager.java
+++ b/worldedit-bukkit/src/main/java/com/fastasyncworldedit/bukkit/util/FoliaTaskManager.java
@@ -128,9 +128,12 @@ public class FoliaTaskManager extends TaskManager {
 
     @Override
     public <T> T syncGlobal(final Supplier<T> supplier) {
-        if (Bukkit.isPrimaryThread()) {
+        // FAWE start - Fix Folia compatibility: In Folia, there is no "primary thread"
+        // Instead, we need to check if we're on a tick thread and handle accordingly
+        if (FoliaSupport.isTickThread()) {
             return supplier.get();
         }
+        // FAWE end
         final FutureTask<T> task = new FutureTask<>(supplier::get);
         Bukkit.getGlobalRegionScheduler().run(WorldEditPlugin.getInstance(), asTickConsumer(task));
         try {

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/SingleThreadQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/SingleThreadQueueExtent.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReentrantLock;
+import com.fastasyncworldedit.core.util.FoliaSupport;
 
 /**
  * Single threaded implementation for IQueueExtent (still abstract) - Does not implement creation of
@@ -254,7 +255,9 @@ public class SingleThreadQueueExtent extends ExtentBatchProcessorHolder implemen
             }
         }
 
-        if (Fawe.isTickThread()) {
+        // FAWE start - Fix Folia compatibility: Always submit to queue handler in Folia
+        // In Folia, direct execution on tick threads can cause synchronization issues
+        if (Fawe.isTickThread() && !FoliaSupport.isFolia()) {
             V result = (V) chunk.call();
             if (result == null) {
                 return (V) (Future) Futures.immediateFuture(null);
@@ -262,6 +265,7 @@ public class SingleThreadQueueExtent extends ExtentBatchProcessorHolder implemen
                 return result;
             }
         }
+        // FAWE end
 
         return (V) Fawe.instance().getQueueHandler().submit(chunk);
     }

--- a/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/SingleThreadQueueExtent.java
+++ b/worldedit-core/src/main/java/com/fastasyncworldedit/core/queue/implementation/SingleThreadQueueExtent.java
@@ -255,8 +255,6 @@ public class SingleThreadQueueExtent extends ExtentBatchProcessorHolder implemen
             }
         }
 
-        // FAWE start - Fix Folia compatibility: Always submit to queue handler in Folia
-        // In Folia, direct execution on tick threads can cause synchronization issues
         if (Fawe.isTickThread() && !FoliaSupport.isFolia()) {
             V result = (V) chunk.call();
             if (result == null) {
@@ -265,7 +263,6 @@ public class SingleThreadQueueExtent extends ExtentBatchProcessorHolder implemen
                 return result;
             }
         }
-        // FAWE end
 
         return (V) Fawe.instance().getQueueHandler().submit(chunk);
     }


### PR DESCRIPTION
## Fix Folia compatibility issue with undo/redo commands

### Problem
`//undo` and `//redo` commands reported success but failed to apply changes in Folia.

### Root Cause
Queue synchronization issues in Folia's region-based threading model:
- `SingleThreadQueueExtent.submitUnchecked()` executed chunks directly instead of submitting to queue handler
- `FoliaTaskManager.syncGlobal()` used incorrect thread detection

### Solution
- **SingleThreadQueueExtent**: Add Folia check to ensure chunks are submitted to queue handler
- **FoliaTaskManager**: Use `FoliaSupport.isTickThread()` instead of `Bukkit.isPrimaryThread()`

### Testing
- [x] `//undo` works in Folia
- [x] `//redo` works in Folia  