### PR TITLE
Fix NPE on tile entity copy

### DIFF
--- a/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_2/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R2/PaperweightGetBlocks.java
@@ -197,23 +197,28 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
-            return null;
-        }
-        return NMS_TO_TILE.apply(blockEntity);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return null;
 
+        BlockPos pos = new BlockPos((x & 15) + (chunkX << 4), y, (z & 15) + (chunkZ << 4));
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null) return null;
+
+        BlockEntity blockEntity = tiles.get(pos);
+        if (blockEntity == null) return null;
+
+        return NMS_TO_TILE.apply(blockEntity);
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return Collections.emptyMap();
+
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null || tiles.isEmpty()) return Collections.emptyMap();
+
+        return AdaptedMap.immutable(tiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R3/PaperweightGetBlocks.java
@@ -197,23 +197,28 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
-            return null;
-        }
-        return NMS_TO_TILE.apply(blockEntity);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return null;
 
+        BlockPos pos = new BlockPos((x & 15) + (chunkX << 4), y, (z & 15) + (chunkZ << 4));
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null) return null;
+
+        BlockEntity blockEntity = tiles.get(pos);
+        if (blockEntity == null) return null;
+
+        return NMS_TO_TILE.apply(blockEntity);
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return Collections.emptyMap();
+
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null || tiles.isEmpty()) return Collections.emptyMap();
+
+        return AdaptedMap.immutable(tiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_20_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_20_R4/PaperweightGetBlocks.java
@@ -198,23 +198,28 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
-            return null;
-        }
-        return NMS_TO_TILE.apply(blockEntity);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return null;
 
+        BlockPos pos = new BlockPos((x & 15) + (chunkX << 4), y, (z & 15) + (chunkZ << 4));
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null) return null;
+
+        BlockEntity blockEntity = tiles.get(pos);
+        if (blockEntity == null) return null;
+
+        return NMS_TO_TILE.apply(blockEntity);
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return Collections.emptyMap();
+
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null || tiles.isEmpty()) return Collections.emptyMap();
+
+        return AdaptedMap.immutable(tiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_R1/PaperweightGetBlocks.java
@@ -198,23 +198,28 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
-            return null;
-        }
-        return NMS_TO_TILE.apply(blockEntity);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return null;
 
+        BlockPos pos = new BlockPos((x & 15) + (chunkX << 4), y, (z & 15) + (chunkZ << 4));
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null) return null;
+
+        BlockEntity blockEntity = tiles.get(pos);
+        if (blockEntity == null) return null;
+
+        return NMS_TO_TILE.apply(blockEntity);
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return Collections.emptyMap();
+
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null || tiles.isEmpty()) return Collections.emptyMap();
+
+        return AdaptedMap.immutable(tiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_11/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_11/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_11/PaperweightGetBlocks.java
@@ -198,23 +198,28 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
-            return null;
-        }
-        return NMS_TO_TILE.apply(blockEntity);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return null;
 
+        BlockPos pos = new BlockPos((x & 15) + (chunkX << 4), y, (z & 15) + (chunkZ << 4));
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null) return null;
+
+        BlockEntity blockEntity = tiles.get(pos);
+        if (blockEntity == null) return null;
+
+        return NMS_TO_TILE.apply(blockEntity);
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return Collections.emptyMap();
+
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null || tiles.isEmpty()) return Collections.emptyMap();
+
+        return AdaptedMap.immutable(tiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_4/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_4/PaperweightGetBlocks.java
@@ -199,23 +199,28 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
-            return null;
-        }
-        return NMS_TO_TILE.apply(blockEntity);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return null;
 
+        BlockPos pos = new BlockPos((x & 15) + (chunkX << 4), y, (z & 15) + (chunkZ << 4));
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null) return null;
+
+        BlockEntity blockEntity = tiles.get(pos);
+        if (blockEntity == null) return null;
+
+        return NMS_TO_TILE.apply(blockEntity);
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return Collections.emptyMap();
+
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null || tiles.isEmpty()) return Collections.emptyMap();
+
+        return AdaptedMap.immutable(tiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_5/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_5/PaperweightGetBlocks.java
@@ -199,23 +199,28 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
-            return null;
-        }
-        return NMS_TO_TILE.apply(blockEntity);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return null;
 
+        BlockPos pos = new BlockPos((x & 15) + (chunkX << 4), y, (z & 15) + (chunkZ << 4));
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null) return null;
+
+        BlockEntity blockEntity = tiles.get(pos);
+        if (blockEntity == null) return null;
+
+        return NMS_TO_TILE.apply(blockEntity);
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return Collections.emptyMap();
+
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null || tiles.isEmpty()) return Collections.emptyMap();
+
+        return AdaptedMap.immutable(tiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_6/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_6/PaperweightGetBlocks.java
@@ -202,23 +202,28 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
-            return null;
-        }
-        return NMS_TO_TILE.apply(blockEntity);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return null;
 
+        BlockPos pos = new BlockPos((x & 15) + (chunkX << 4), y, (z & 15) + (chunkZ << 4));
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null) return null;
+
+        BlockEntity blockEntity = tiles.get(pos);
+        if (blockEntity == null) return null;
+
+        return NMS_TO_TILE.apply(blockEntity);
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return Collections.emptyMap();
+
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null || tiles.isEmpty()) return Collections.emptyMap();
+
+        return AdaptedMap.immutable(tiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override

--- a/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightGetBlocks.java
+++ b/worldedit-bukkit/adapters/adapter-1_21_9/src/main/java/com/sk89q/worldedit/bukkit/adapter/impl/fawe/v1_21_9/PaperweightGetBlocks.java
@@ -202,23 +202,28 @@ public class PaperweightGetBlocks extends AbstractBukkitGetBlocks<ServerLevel, L
 
     @Override
     public FaweCompoundTag tile(final int x, final int y, final int z) {
-        BlockEntity blockEntity = getChunk().getBlockEntity(new BlockPos((x & 15) + (
-                chunkX << 4), y, (z & 15) + (
-                chunkZ << 4)));
-        if (blockEntity == null) {
-            return null;
-        }
-        return NMS_TO_TILE.apply(blockEntity);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return null;
 
+        BlockPos pos = new BlockPos((x & 15) + (chunkX << 4), y, (z & 15) + (chunkZ << 4));
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null) return null;
+
+        BlockEntity blockEntity = tiles.get(pos);
+        if (blockEntity == null) return null;
+
+        return NMS_TO_TILE.apply(blockEntity);
     }
 
     @Override
     public Map<BlockVector3, FaweCompoundTag> tiles() {
-        Map<BlockPos, BlockEntity> nmsTiles = getChunk().getBlockEntities();
-        if (nmsTiles.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return AdaptedMap.immutable(nmsTiles, posNms2We, NMS_TO_TILE);
+        LevelChunk chunk = getChunk();
+        if (chunk == null) return Collections.emptyMap();
+
+        Map<BlockPos, BlockEntity> tiles = chunk.getBlockEntities();
+        if (tiles == null || tiles.isEmpty()) return Collections.emptyMap();
+
+        return AdaptedMap.immutable(tiles, posNms2We, NMS_TO_TILE);
     }
 
     @Override


### PR DESCRIPTION
Fixed a NullPointerException that occurs when copying blocks with tile entities in Folia.