### PR TITLE
fix(folia): use entity scheduler for getState() to avoid off-region t…

### DIFF
--- a/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntity.java
+++ b/worldedit-bukkit/src/main/java/com/sk89q/worldedit/bukkit/BukkitEntity.java
@@ -30,7 +30,6 @@ import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.util.Location;
 import com.sk89q.worldedit.world.NullWorld;
 import io.papermc.lib.PaperLib;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.EntityType;
 
 import javax.annotation.Nullable;
@@ -109,13 +108,32 @@ public class BukkitEntity implements Entity {
             BukkitImplAdapter adapter = WorldEditPlugin.getInstance().getBukkitImplAdapter();
             if (adapter != null) {
                 if (FoliaUtil.isFoliaServer()) {
-                    org.bukkit.Location location = entity.getLocation();
                     CompletableFuture<BaseEntity> future = new CompletableFuture<>();
-                    Bukkit.getServer().getRegionScheduler().run(
+                    // Use entity scheduler (not region scheduler) to guarantee we run on
+                    // the entity's owning region thread. regionScheduler.run(location) would
+                    // target the region that owns that location, which may differ from the
+                    // region that owns the entity itself, causing Folia thread-check failures.
+                    boolean scheduled = entity.getScheduler().execute(
                             WorldEditPlugin.getInstance(),
-                            location,
-                            scheduledTask -> future.complete(adapter.getEntity(entity))
+                            () -> {
+                                BaseEntity base = adapter.getEntity(entity);
+                                // Force-evaluate the lazy NBT tag while we are still on the
+                                // entity's region thread. LazyBaseEntity.getNbt() would otherwise
+                                // run the supplier via TaskManager.sync(), which on Folia is a
+                                // no-op and executes on whatever (async) thread calls it later.
+                                if (base != null) {
+                                    base.getNbt();
+                                }
+                                future.complete(base);
+                            },
+                            () -> future.complete(null), // retired: entity was removed
+                            1L
                     );
+                    if (!scheduled) {
+                        // Entity scheduler rejected the task (e.g. plugin disabled); fall back
+                        // to returning null so the copy operation skips this entity cleanly.
+                        return null;
+                    }
                     return future.join();
                 }
                 return adapter.getEntity(entity);


### PR DESCRIPTION
…hread errors

On Folia, every entity is owned by a specific region thread. The previous implementation used `regionScheduler.run(location, ...)` to schedule entity state access, but this targets the region that *contains the given location* rather than the region that *owns the entity*. In edge cases (chunk boundary transitions, region re-assignments) these can differ, causing:

  IllegalStateException: Accessing entity state off owning region's thread

Two bugs are fixed:

1. Switch from `Bukkit.getServer().getRegionScheduler().run(location, task)` to `entity.getScheduler().execute(plugin, task, retired, delay)`. The EntityScheduler always dispatches on the entity's actual owning region thread, regardless of the entity's current location.

2. Force-evaluate the lazy NBT tag (`base.getNbt()`) while still inside the entity scheduler callback. `LazyBaseEntity.getNbt()` delegates to `TaskManager.sync()`, which on Folia short-circuits and runs the supplier directly on the calling thread. Without this eager evaluation the supplier would run later on an async copy thread, also off the owning region.

Also remove the now-unused `import org.bukkit.Bukkit` statement.